### PR TITLE
notebook docs: typos + nbviewer issues

### DIFF
--- a/docs/propkatraj-example.ipynb
+++ b/docs/propkatraj-example.ipynb
@@ -46,7 +46,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This `Universe` contains a trajectory of an adenylate kinase (AdK) protein with 3341 atoms, 214 residues."
+    "This `Universe` contains a trajectory of an adenylate kinase protein with 3341 atoms, 214 residues."
    ]
   },
   {
@@ -60,7 +60,7 @@
      "text": [
       "number of atoms:  3341\n",
       "number of residues: 214\n",
-      "unique residues: {'THR', 'SER', 'PHE', 'TYR', 'ASP', 'MET', 'ILE', 'CYS', 'GLN', 'GLY', 'LEU', 'ALA', 'GLU', 'HSD', 'LYS', 'VAL', 'PRO', 'ASN', 'ARG'}\n"
+      "unique residues: {'ASP', 'ARG', 'VAL', 'GLN', 'GLY', 'CYS', 'PRO', 'SER', 'THR', 'HSD', 'GLU', 'ALA', 'LYS', 'TYR', 'MET', 'LEU', 'PHE', 'ASN', 'ILE'}\n"
      ]
     }
    ],
@@ -90,7 +90,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can call the `help()` method to get information on how to use `PropkaTraj`. This includes information on what parameters can be passed to the class, example uses and notes on known bugs and limitations."
+    "We can call the `help()` method to get information on how to use `PropkaTraj`. This includes information on; what parameters can be passed to the class, example uses, known bugs, and limitations."
    ]
   },
   {
@@ -112,7 +112,9 @@
       " |  Per residue pKa analysis of a trajectory.\n",
       " |  \n",
       " |  Runs :program:`propka` on the titrateable residues of the selected\n",
-      " |  AtomGroup on each frame in the trajectory.\n",
+      " |  AtomGroup on each frame in the trajectory. Run the analysis with\n",
+      " |  :meth:`PropkaTraj.run`, and pKa values will be stored in a\n",
+      " |  :class:`pandas.DataFrame` named :attr:`PropkaTraj.pkas`.\n",
       " |  \n",
       " |  Parameters\n",
       " |  ----------\n",
@@ -132,23 +134,15 @@
       " |      RuntimeError exception on those frames. [`False`]\n",
       " |  \n",
       " |  \n",
-      " |  Returns\n",
-      " |  -------\n",
-      " |  pkas : :class:`pandas.DataFrame`\n",
-      " |      DataFrame giving the estimated pKa value for each titrateable residue\n",
-      " |      for each trajectory frame. Residue numbers are given as column labels,\n",
-      " |      times as row labels.\n",
-      " |  \n",
-      " |  \n",
       " |  Notes\n",
       " |  -----\n",
       " |  Currently only the default behaviour supplemented with the `--quiet` flag\n",
       " |  of :program:`propka` is used.\n",
       " |  \n",
-      " |  Currently, temporary :program:`propka` files are written in the current\n",
-      " |  working directory. This will leave a ``current.pka`` and\n",
-      " |  ``current.propka_input`` file. These are the temporary files for the final\n",
-      " |  frame and can be removed safely.\n",
+      " |  Temporary :program:`propka` files are written in the current working\n",
+      " |  directory. This will leave a ``current.pka`` and ``current.propka_input``\n",
+      " |  file. These are the temporary files for the final frame and can be removed\n",
+      " |  safely.\n",
       " |  \n",
       " |  Current known issues:\n",
       " |  \n",
@@ -241,7 +235,7 @@
       " |    fig.savefig('pKa-plot.png')\n",
       " |  \n",
       " |  \n",
-      " |  .. versionadded:: 1.0.3\n",
+      " |  .. versionadded:: 1.1.0\n",
       " |  \n",
       " |  Method resolution order:\n",
       " |      PropkaTraj\n",
@@ -317,7 +311,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We then need to call the `run()` method to calculate the pKas. It is worth noting that run can take optional arguments; verbose (which we use here to show a progress bar), start, stop, and step. The latter three control what frames are analysed. See https://www.mdanalysis.org/docs/documentation_pages/analysis/base.html for more details."
+    "We then need to call the `run()` method to calculate the pKas. It is worth noting that run can take optional arguments; verbose, start, stop, and step. The latter three control what frames are analysed. See https://www.mdanalysis.org/docs/documentation_pages/analysis/base.html for more details."
    ]
   },
   {
@@ -325,20 +319,6 @@
    "execution_count": 7,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "34dd1b2989df48a98da0566d926d6a68",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(FloatProgress(value=0.0, max=98.0), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stderr",
      "output_type": "stream",
@@ -354,16 +334,9 @@
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "<propkatraj.propkatraj.PropkaTraj at 0x7f7d52668d90>"
+       "<propkatraj.propkatraj.PropkaTraj at 0x7fcc0dbe8d30>"
       ]
      },
      "execution_count": 7,
@@ -372,14 +345,14 @@
     }
    ],
    "source": [
-    "pkatraj.run(verbose=True)"
+    "pkatraj.run()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once run, the calculated pKas are stored for each titrateable residue is stored in a pandas Dataframe (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html) under the attribute `pkas`."
+    "Once run, the timeseries of calculated pKas for each titrateable residue is stored in a pandas Dataframe (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html) under the attribute `pkas`."
    ]
   },
   {

--- a/docs/propkatraj-example.ipynb
+++ b/docs/propkatraj-example.ipynb
@@ -352,7 +352,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once run, the timeseries of calculated pKas for each titrateable residue is stored in a pandas Dataframe (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html) under the attribute `pkas`."
+    "Once run, the timeseries of calculated pKas for the titrateable residue is stored in a pandas Dataframe (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html) under the attribute `pkas`."
    ]
   },
   {


### PR DESCRIPTION
FIxes #27 

Changes:
  - Fixes some typos.
  - Removes `verbose=True` from `run()`.