### PR TITLE
Added compatibility with MDAnalysis 2.4

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,6 @@ Chronological list of authors
 
 2020
   - Irfan Alibay
+
+2023
+  - Ian Kenney

--- a/propkatraj/__init__.py
+++ b/propkatraj/__init__.py
@@ -1,4 +1,4 @@
-from .propkatraj import get_propka, PropkaTraj
+from .propkatraj import PropkaTraj
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/propkatraj/propkatraj.py
+++ b/propkatraj/propkatraj.py
@@ -5,7 +5,7 @@
 
 from __future__ import print_function, division
 
-from six import string_types, StringIO, raise_from
+from six import StringIO, raise_from
 import os
 
 import pandas as pd
@@ -14,7 +14,6 @@ import numpy as np
 import propka.run as pk
 import MDAnalysis as mda
 from MDAnalysis.analysis.base import AnalysisBase
-from MDAnalysis.lib.util import deprecate
 
 import warnings
 import logging
@@ -152,7 +151,10 @@ class PropkaTraj(AnalysisBase):
     def __init__(self, atomgroup, select='protein', skip_failure=False,
                  **kwargs):
         if select is not None:
-            self.ag = atomgroup.select_atoms(select).atoms
+            if not isinstance(select, str):
+                self.ag = atomgroup.atoms[select].atoms
+            else:
+                self.ag = atomgroup.select_atoms(select).atoms
         else:
             self.ag = atomgroup.atoms
 
@@ -225,146 +227,6 @@ class PropkaTraj(AnalysisBase):
                                                 self.failed_frames_log))
             logging.warning(wmsg)
 
-        self.pkas = pd.DataFrame(self._pkas, index=pd.Float64Index(self.times,
-                                 name='time'), columns=self._columns)
-
-
-@deprecate(release="1.1.0", remove="2.0.0",
-           message="Use ``PropkaTraj(u, ..).run().pkas instead.")
-def get_propka(universe, sel='protein', start=None, stop=None, step=None,
-               skip_failure=False):
-    """Get and store pKas for titrateable residues along trajectory.
-
-    Parameters
-    ----------
-    universe : :class:`MDAnalysis.Universe`
-        Universe to obtain pKas for.
-    sel : str, array_like
-        Selection string to use for selecting atoms to use from given
-        ``universe``. Can also be a numpy array or list of atom indices to use.
-    start : int
-        Frame of trajectory to start from. `None` means start from beginning.
-    stop : int
-        Frame of trajectory to end at. `None` means end at trajectory end.
-    step : int
-        Step by which to iterate through trajectory frames. propka is slow,
-        so set according to how finely you need resulting timeseries.
-    skip_failure : bool
-        If set to ``True``, skip frames where PROPKA fails. If ``False``
-        raise an exception. The default is ``False``.
-        Log file (at level warning) contains information on failed frames.
-
-
-    Results
-    -------
-    pkas : :class:`pandas.DataFrame`
-        DataFrame giving estimated pKa value for each residue for each
-        trajectory frame. Residue numbers are given as column labels, times as
-        row labels.
-
-
-    Notes
-    -----
-    Currently, temporary :program:`propka` files are written in the same
-    directory as the input trajectory file. This will leave a ``current.pka``
-    and ``current.propka_input`` file post-analysis. These are the temporary
-    files for the final frame and can be removed. Should the trajectory file
-    not have an input directory (e.g. when using MDAnalysis' `fetch_mmtf`
-    method), then the files will be written to the current directory.
-
-    Known issues:
-
-    1. Due to the current behaviour of the MDAnalysis PDBWriter, non-protein
-       atoms are written to PDBs using `ATOM` records instead of `HETATM`.
-       This is likely to lead to undefined behaviour in :program:`propka`,
-       which will likely expect `HETATM` inputs. We recommend users to only
-       pass protein atoms for now. See the following issue for more details:
-       https://github.com/Becksteinlab/propkatraj/issues/24
-
-    """
-
-    # need AtomGroup to write out for propka
-    if isinstance(sel, string_types):
-        atomsel = universe.select_atoms(sel)
-    elif isinstance(sel, (list, np.ndarray)):
-        atomsel = universe.atoms[sel]
-
-    # Issue #23 (keep until the PDBWriter is fixed)
-    if len(atomsel.select_atoms('not protein')) > 0:
-        wmsg = ("Non protein atoms passed to propka 3.1.\n MDAnalysis' "
-                "PDBWriter does not currently write non-standard residues "
-                "correctly as HETATM records and this may lead to "
-                "incorrect pKa predictions.\n"
-                "See https://github.com/Becksteinlab/propkatraj/issues/24 "
-                " for more details")
-        warnings.warn(wmsg)
-
-    # "filename" for our stream
-    # use same name so that propka overwrites
-    try:
-        newname = os.path.join(os.path.dirname(universe.filename),
-                               'current.pdb')
-    except TypeError:
-        # we have a trajectory without a directory
-        newname = os.path.join(os.path.curdir, 'current.pdb')
-
-    # progress logging output (because this is slow...)
-    pm = mda.lib.log.ProgressMeter(universe.trajectory.n_frames,
-                                   format="{step:5d}/{numsteps} t={time:12.3f} ps  "
-                                   "[{percentage:5.1f}%]",
-                                   interval=1)
-
-    times = []
-    pkas = []
-    failed_frames = 0
-    failed_frames_log = []
-    for ts in universe.trajectory[start:stop:step]:
-        pm.echo(ts.frame, time=ts.time)
-
-        # we create a named stream to write the atoms of interest into
-        pstream = mda.lib.util.NamedStream(StringIO(), newname)
-        atomsel.write(pstream)
-
-        pstream.reset()         # reset for reading
-
-        # we feed the stream to propka, and it reads it as if it were a file on
-        # disk
-        try:
-            mol = pk.single(pstream, optargs=['--quiet'])
-        except (IndexError, AttributeError) as err:
-            # https://github.com/Becksteinlab/propkatraj/issues/13
-            # https://github.com/Becksteinlab/propkatraj/issues/10
-            err_msg = "{0} (failure {2}): failing frame {1}".format(
-                    universe.trajectory.filename, ts.frame, failed_frames)
-            if not skip_failure:
-                raise_from(RuntimeError(err_msg), err)
-            else:
-                failed_frames += 1
-                failed_frames_log.append(ts.frame)
-                logging.warning(err_msg)
-                continue
-        finally:
-            pstream.close(force=True)  # deallocate
-
-        # parse propka data structures to get out what we actually want
-        confname = mol.conformation_names[0]
-        conformation = mol.conformations[confname]
-        groups = conformation.get_titratable_groups()
-
-        # extract pka estimates from each residue
-        pkas.append([g.pka_value for g in groups])
-
-        # record time
-        times.append(ts.time)
-
-    if failed_frames_log:
-        logging.warning('number of failed frames = {0}'.format(failed_frames))
-        logging.warning('percent failure = {0:.3f}%'.format(
-            float(failed_frames)/len(universe.trajectory)*100))
-        logging.warning('failed frames: %r', failed_frames_log)
-
-    # a `pandas.DataFrame` is a good data structure for this data
-    df = pd.DataFrame(pkas, index=pd.Float64Index(times, name='time'),
-                      columns=[g.atom.resNumb for g in groups])
-
-    return df
+        self.pkas = pd.DataFrame(self._pkas, index=pd.Index(self.times,
+                                 name='time', dtype='float64'),
+                                 columns=self._columns)

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,5 @@ setup(name='propkatraj',
       license='GPLv3',
       long_description=open('README.md').read(),
       long_description_content_type='text/markdown; variant=GFM',
-      install_requires=['six', 'numpy', 'pandas', 'MDAnalysis<2.0.0', 'propka==3.1']
+      install_requires=['six', 'numpy', 'pandas', 'MDAnalysis', 'propka==3.1']
       )


### PR DESCRIPTION
- Removed the `get_propka` function (next version must be 2.0.0)
- PropkaTraj constructor accepts atom indices for selections
- Pandas Index with a dtype of float64 instead of Float64Index, per deprecation warning from Pandas
- Removed removed tests for `get_propka` and changed the baseanalysis test names to be being the standard
- Expanded parameters for `test_single_frame_regression`
- Removed MDAnalysis version constraint in setup.py