### PR TITLE
Removing Python 3.8 from CI

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         mdanalysis-version: ["latest", "develop"]
 
     steps:


### PR DESCRIPTION
CI is failing because of Python version 3.8.