### PR TITLE
install propkatraj for doc building

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,24 +18,34 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0         
 
     - name: setup_miniconda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: 3.11
         environment-file: docs/requirements.yaml
-        auto-update-conda: true
-        channel-priority: flexible
-        channels: conda-forge
+        add-pip-as-python-dependency: true
+        architecture: x64
+
         miniforge-variant: Mambaforge
         use-mamba: true
+        channels: conda-forge
+
+        activate-environment: propkatrajdocs
+        auto-update-conda: true
+        auto-activate-base: false
+        show-channel-urls: true 
 
     - name: install dependencies
       run: |
         pip install pandas MDAnalysis propka==3.1
+
+    - name: install propkatraj
+      run: |
+        pip install .
 
     - name: build docs
       run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: "${{ github.ref }}-${{ github.head_ref }}"
@@ -52,6 +55,7 @@ jobs:
         cd docs && sphinx-build -T -E --keep-going -b html -D language=en sphinx html
 
     - name: deploy docs
+      if: github.event_name != 'pull_request'    
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -3,11 +3,9 @@ on:
   push:
     branches:
       - main
-      - dev
   pull_request:
     branches:
       - main
-      - dev
   schedule:
     - cron: "0 0 * * 0"
 

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -1,6 +1,6 @@
 name: propkatrajdocs
 channels:
-  - default
+  - conda-forge
 dependencies:
   - python
   - pip


### PR DESCRIPTION
- fix #66
- install propkatraj package before building docs
- updated docs CI (updated version, make clear that we use conda-forge channel)
- run docs CI on each PR (and deploy on push to main)