### PR TITLE
Replace pkg_resources for test data paths

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,6 @@ Chronological list of authors
 
 2023
   - Ian Kenney
+
+2026
+  - Miro (@Mirochill)

--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -2,6 +2,7 @@ name: propkatraj
 channels:
   - conda-forge
 dependencies:
+  - setuptools>=61.2,<81
   - MDAnalysis>=2.0.0
   - MDAnalysisTests>=2.0.0
   - pandas

--- a/propkatraj/tests/datafiles.py
+++ b/propkatraj/tests/datafiles.py
@@ -12,18 +12,14 @@ __all__ = [
 
 ]
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
-PSF_FRAME_ZERO_PKA = resource_filename(__name__,
-                                       './data/psf_ref_frame0.pka')
-PSF_FRAME_NINETY_PKA = resource_filename(__name__,
-                                         './data/psf_ref_frame90.pka')
+_DATA = files(__package__).joinpath("data")
+
+PSF_FRAME_ZERO_PKA = str(_DATA.joinpath("psf_ref_frame0.pka"))
+PSF_FRAME_NINETY_PKA = str(_DATA.joinpath("psf_ref_frame90.pka"))
 # Issue #10
-INDEXERR_FRAME14_GRO = resource_filename(__name__,
-                                         './data/indexerr_frame14.gro')
-INDEXERR_FRAME14_XTC = resource_filename(__name__,
-                                         './data/indexerr_frame14.xtc')
-ATTERR_FRAME1_PDB = resource_filename(__name__,
-                                      './data/atterr_frame1.pdb')
-ATTERR_FRAME1_XTC = resource_filename(__name__,
-                                      './data/atterr_frame1.xtc')
+INDEXERR_FRAME14_GRO = str(_DATA.joinpath("indexerr_frame14.gro"))
+INDEXERR_FRAME14_XTC = str(_DATA.joinpath("indexerr_frame14.xtc"))
+ATTERR_FRAME1_PDB = str(_DATA.joinpath("atterr_frame1.pdb"))
+ATTERR_FRAME1_XTC = str(_DATA.joinpath("atterr_frame1.xtc"))

--- a/propkatraj/tests/datafiles.py
+++ b/propkatraj/tests/datafiles.py
@@ -23,3 +23,5 @@ INDEXERR_FRAME14_GRO = str(_DATA.joinpath("indexerr_frame14.gro"))
 INDEXERR_FRAME14_XTC = str(_DATA.joinpath("indexerr_frame14.xtc"))
 ATTERR_FRAME1_PDB = str(_DATA.joinpath("atterr_frame1.pdb"))
 ATTERR_FRAME1_XTC = str(_DATA.joinpath("atterr_frame1.xtc"))
+
+del _DATA

--- a/propkatraj/tests/test_regression.py
+++ b/propkatraj/tests/test_regression.py
@@ -44,8 +44,7 @@ def glu_ref():
 
 def pka_from_file(filename):
     columns = ['resname', 'resnum', 'chain', 'pka', 'model-pka']
-    df = pd.read_csv(filename, names=columns, skiprows=1,
-                     delim_whitespace=True)
+    df = pd.read_csv(filename, names=columns, skiprows=1, sep=r"\s+")
     df.sort_values(by=['resnum'], inplace=True)
     resnums = df['resnum'].to_numpy()
     pkas = df['pka'].to_numpy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools >= 61.2",
+  "setuptools >= 61.2,<81",  # pkg_resources are currently required and were removed in 81.0.0
   "versioningit",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Refs #80

## Summary

- Replaces `pkg_resources.resource_filename()` in `propkatraj.tests.datafiles` with `importlib.resources.files()`.
- Keeps the exported test data constants as string paths for existing callers.
- Removes the first-party `pkg_resources` import currently present in the repository.

## Remote CI

- Read the Docs is currently failing before the docs build because importing `propkatraj` imports the pinned dependency `propka==3.1.0`, and `propka.lib` imports `pkg_resources` in the Python 3.14 Read the Docs environment.
- That remaining runtime import is outside `propkatraj.tests.datafiles`; this PR is therefore a narrow first-party cleanup, not a complete fix for the broader runtime `propka` dependency path.

## Validation

- `rg -n pkg_resources|resource_filename|importlib.resources|files\( propkatraj/tests/datafiles.py`
- `rg -n pkg_resources|resource_filename .`
- `git diff --check`
- `git diff --check upstream/main..HEAD`
- Tests not run locally